### PR TITLE
Allow multi-line method signatures and method chaining

### DIFF
--- a/intellij_codestyle_accuro.xml
+++ b/intellij_codestyle_accuro.xml
@@ -59,8 +59,9 @@
     <option name="SPACE_WITHIN_EMPTY_ARRAY_INITIALIZER_BRACES" value="true" />
     <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
     <option name="SPACE_BEFORE_ANNOTATION_ARRAY_INITIALIZER_LBRACE" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="5" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+    <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
### Change the following 3 line-wrap related rules:
**"Method declaration parameters" to "Chop down if long"**
- Required for when many objects are dependency injected into constructors, so the method signature isn't a single line which is  hundreds of characters long

**Before:**
![image](https://user-images.githubusercontent.com/42549626/74360613-40fea300-4d7a-11ea-8160-39f2738ce043.png)
**After:**
![image](https://user-images.githubusercontent.com/42549626/74360656-54117300-4d7a-11ea-8879-841bb3139496.png)

**"Chained method calls" to "Wrap always"
	"Wrap first call" to "true"**
- Required for fluent method chaining, such as Java streams or builder patterns (as a bonus, helps highlight the "messenger chain" code smell and helps enforce "Clean Code" practices)

**Before:**
![image](https://user-images.githubusercontent.com/42549626/74360753-7acfa980-4d7a-11ea-8ae9-b736fb37dce5.png)
**After:**
![image](https://user-images.githubusercontent.com/42549626/74360807-963ab480-4d7a-11ea-84ca-6242bf02ffc5.png)