### PR TITLE
Accuro style: remove KEEP_LINE_BREAKS setting to prevent aggressive ugly line breaking

### DIFF
--- a/intellij_codestyle_accuro.xml
+++ b/intellij_codestyle_accuro.xml
@@ -29,7 +29,6 @@
     <option name="JD_INDENT_ON_CONTINUATION" value="true" />
   </JavaCodeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="KEEP_LINE_BREAKS" value="false" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />


### PR DESCRIPTION
### Change
Remove the KEEP_LINE_BREAKS=false setting from Accuro's checkstyle.
This will allow developers to define their own line breaks instead of aggressively applying styling that may not be desirable.

### Justifying Examples
**Without the setting, allowing multi-line array initialization**
![without_setting_schema](https://user-images.githubusercontent.com/17015592/75917636-28c8f380-5e0f-11ea-9447-864b5efc4f0a.png)
**With the setting, squashing it all to one line**
![with_settings_schema](https://user-images.githubusercontent.com/17015592/75917741-54e47480-5e0f-11ea-924d-d3edc1ed2147.png)

**Without the setting, allowing formatted comparators**
![without_setting_test](https://user-images.githubusercontent.com/17015592/75917769-62016380-5e0f-11ea-9ecc-1891e33c101b.png)

**With the setting, wrapping and aligning**
![with_setting_test](https://user-images.githubusercontent.com/17015592/75917801-6ded2580-5e0f-11ea-8e5f-9dab999baf53.png)

With KEEP_LINE_BREAKS value set `true`, the styling choices of the individual developer as to where to add new lines is preserved. It does allow for some ugliness (see below) but generally developers do not do things like this example

**This will be allowed but I don't think I've ever actually seen a developer do it**
![extra_ugly_newline](https://user-images.githubusercontent.com/17015592/75918405-83168400-5e10-11ea-9c93-77571767aaab.png)

### Alternative
An alternative would be to apply 'chop down if long' or 'wrap if long' settings on more statements (it is an option for array initialization, method calls and params, etc) however the blanket application of these things would override the generally/hopefully sensible formatting that most developers already do. 

### Justification
In my opinion the checkstyle is more applicable for bracket spacing and minor newline enforcement (ie if/for statements) and less for when to apply wrapping/newlines, which can be especially jarring for common Accuro line-length idioms, regardless of their objective 'bad'ness.
