### PR TITLE
group com.qhrtechnologies with first-party imports

### DIFF
--- a/intellij_codestyle_accuro.xml
+++ b/intellij_codestyle_accuro.xml
@@ -15,6 +15,7 @@
         <package name="com.optimedirect" withSubpackages="true" static="false" />
         <package name="com.optimedsoftware" withSubpackages="true" static="false" />
         <package name="com.qhrtech" withSubpackages="true" static="false" />
+        <package name="com.qhrtechnologies" withSubpackages="true" static="false" />
         <package name="" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="java" withSubpackages="true" static="false" />


### PR DESCRIPTION
## Change
Group `com.qhrtechnologies.*` with other first-party library import statements in the Accuro Java style.

## Justification
The difference in ordering seldom shows up (only when certain commercial third-party libraries are also in use), but since the package represents first-party code, it should be always grouped with other first-party imports.

In this case, the path points to the Registry Interface project: https://github.com/qhrtech/registry-interface

### Current output
![image](https://user-images.githubusercontent.com/42549609/76568785-d9b63a80-646e-11ea-8779-cee9406d36f2.png)
